### PR TITLE
Refactor currency handling

### DIFF
--- a/Scripts/Managers/UpgradeService.gd
+++ b/Scripts/Managers/UpgradeService.gd
@@ -2,24 +2,25 @@ extends Node
 class_name UpgradeService
 
 @export var progress_event_bus: PlayerProgressEventBus
+var current_currency: Currency.CurrencyType = Currency.CurrencyType.FIAT
 
 func _ready() -> void:
         if progress_event_bus == null:
                 progress_event_bus = preload("res://Resources/Upgrades/MainPlayerProgressEventBus.tres")
 
-func can_afford(data: SkillNodeData, use_bitcoin: bool = false) -> bool:
+func can_afford(data: SkillNodeData, currency: Currency.CurrencyType = current_currency) -> bool:
         if data == null:
                 return false
-        var cost = data.upgrade_cost(use_bitcoin)
-        var balance = BitcoinWallet.get_bitcoin_balance() if use_bitcoin else BitcoinWallet.get_fiat_balance()
+        var cost = data.upgrade_cost(currency)
+        var balance = BitcoinWallet.get_bitcoin_balance() if currency == Currency.CurrencyType.BITCOIN else BitcoinWallet.get_fiat_balance()
         return balance >= cost
 
-func purchase_upgrade(data: SkillNodeData, use_bitcoin: bool = false) -> bool:
+func purchase_upgrade(data: SkillNodeData, currency: Currency.CurrencyType = current_currency) -> bool:
         if data == null:
                 return false
-        if !can_afford(data, use_bitcoin):
+        if !can_afford(data, currency):
                 return false
-        if !data.buy_upgrade(use_bitcoin):
+        if !data.buy_upgrade(currency):
                 return false
         _emit_upgrade_event(data)
         return true

--- a/Scripts/Managers/UpgradeService.gd
+++ b/Scripts/Managers/UpgradeService.gd
@@ -2,20 +2,20 @@ extends Node
 class_name UpgradeService
 
 @export var progress_event_bus: PlayerProgressEventBus
-var current_currency: Currency.CurrencyType = Currency.CurrencyType.FIAT
+var current_currency: Constants.CurrencyType = Constants.CurrencyType.FIAT
 
 func _ready() -> void:
         if progress_event_bus == null:
                 progress_event_bus = preload("res://Resources/Upgrades/MainPlayerProgressEventBus.tres")
 
-func can_afford(data: SkillNodeData, currency: Currency.CurrencyType = current_currency) -> bool:
+func can_afford(data: SkillNodeData, currency: Constants.CurrencyType = current_currency) -> bool:
         if data == null:
                 return false
         var cost = data.upgrade_cost(currency)
-        var balance = BitcoinWallet.get_bitcoin_balance() if currency == Currency.CurrencyType.BITCOIN else BitcoinWallet.get_fiat_balance()
+        var balance = BitcoinWallet.get_bitcoin_balance() if currency == Constants.CurrencyType.BITCOIN else BitcoinWallet.get_fiat_balance()
         return balance >= cost
 
-func purchase_upgrade(data: SkillNodeData, currency: Currency.CurrencyType = current_currency) -> bool:
+func purchase_upgrade(data: SkillNodeData, currency: Constants.CurrencyType = current_currency) -> bool:
         if data == null:
                 return false
         if !can_afford(data, currency):

--- a/Scripts/SkillsTree/SkillNode.gd
+++ b/Scripts/SkillsTree/SkillNode.gd
@@ -67,7 +67,7 @@ enum FEATURE_TYPE {
 var is_maxed_out: bool = false
 var node_identifier: int = 0
 var node_state: SkillNodeData.DataStatus = SkillNodeData.DataStatus.LOCKED
-var current_currency: Currency.CurrencyType = UpgradeService.current_currency
+var current_currency: Constants.CurrencyType = UpgradeService.current_currency
 
 const implements = [
 	preload("res://Scripts/PersistenceDataSystem/IPersistenceData.gd")
@@ -89,7 +89,7 @@ func _ready() -> void:
                 lock()
         _update_node_line_points()
         current_currency = UpgradeService.current_currency
-        set_currency_icon(current_currency == Currency.CurrencyType.BITCOIN)
+        set_currency_icon(current_currency == Constants.CurrencyType.BITCOIN)
         _update_skill_node_ui(skillnode_data.upgrade_name, skillnode_data.upgrade_description, skillnode_data.upgrade_cost(current_currency))
 
 #region Public API
@@ -188,7 +188,7 @@ func _update_skill_node_ui(_title: String, _desc: String, _cost: float) -> void:
 
 func _update_cost_background() -> void:
         cost_background.remove_theme_stylebox_override("panel")
-        var balance: float = BitcoinWallet.get_bitcoin_balance() if UpgradeService.current_currency == Currency.CurrencyType.BITCOIN else BitcoinWallet.get_fiat_balance()
+        var balance: float = BitcoinWallet.get_bitcoin_balance() if UpgradeService.current_currency == Constants.CurrencyType.BITCOIN else BitcoinWallet.get_fiat_balance()
         var s_cost: float = skillnode_data.upgrade_cost(UpgradeService.current_currency)
 	
 	if is_maxed_out: 
@@ -224,9 +224,9 @@ func _set_line_points() -> void:
 		skill_line.add_point(current_node_center_local)
 		skill_line.add_point(parent_node_center_local)
 
-func _on_currency_changed(currency: Currency.CurrencyType) -> void:
+func _on_currency_changed(currency: Constants.CurrencyType) -> void:
         current_currency = currency
-        set_currency_icon(currency == Currency.CurrencyType.BITCOIN)
+        set_currency_icon(currency == Constants.CurrencyType.BITCOIN)
         _update_skill_node_ui(skillnode_data.upgrade_name, skillnode_data.upgrade_description, skillnode_data.upgrade_cost(currency))
 
 func set_currency_icon(btc_icon: bool) -> void:
@@ -237,7 +237,7 @@ func set_currency_icon(btc_icon: bool) -> void:
 #region Signals
 
 func _on_mouse_entered() -> void:
-        # skill_info_panel.activate_panel(skillnode_data.upgrade_name, skillnode_data.upgrade_description, int(skillnode_data.upgrade_cost(UpgradeService.current_currency)), UpgradeService.current_currency == Currency.CurrencyType.BITCOIN, is_maxed_out)
+        # skill_info_panel.activate_panel(skillnode_data.upgrade_name, skillnode_data.upgrade_description, int(skillnode_data.upgrade_cost(UpgradeService.current_currency)), UpgradeService.current_currency == Constants.CurrencyType.BITCOIN, is_maxed_out)
 	if sound_effect_component_ui == null: return
 	sound_effect_component_ui.set_and_play_sound(on_mouse_entered_effect)
 

--- a/Scripts/SkillsTree/SkillNodeData.gd
+++ b/Scripts/SkillsTree/SkillNodeData.gd
@@ -71,10 +71,10 @@ var status: DataStatus = DataStatus.LOCKED
 
 #region Main
 
-func buy_upgrade(currency_type: Currency.CurrencyType = Currency.CurrencyType.FIAT) -> bool:
+func buy_upgrade(currency_type: Constants.CurrencyType = Constants.CurrencyType.FIAT) -> bool:
         if upgrade_level >= upgrade_max_level: return false
 
-        var success: bool = _buy_with_bitcoin() if currency_type == Currency.CurrencyType.BITCOIN else _buy_with_fiat()
+        var success: bool = _buy_with_bitcoin() if currency_type == Constants.CurrencyType.BITCOIN else _buy_with_fiat()
         if success:
                 check_next_tier_unlock()
                 check_upgrade_maxed_out()
@@ -84,7 +84,7 @@ func set_id(id:int = 0) -> void:
 	_id = id
 
 func _buy_with_bitcoin() -> bool:
-        if BitcoinWallet.spend_bitcoin(upgrade_cost(Currency.CurrencyType.BITCOIN)):
+        if BitcoinWallet.spend_bitcoin(upgrade_cost(Constants.CurrencyType.BITCOIN)):
 		upgrade_level = min(upgrade_level+1, upgrade_max_level)
 		return true
 	else:
@@ -93,26 +93,26 @@ func _buy_with_bitcoin() -> bool:
 
 
 func _buy_with_fiat() -> bool:
-        if BitcoinWallet.spend_fiat(upgrade_cost(Currency.CurrencyType.FIAT)):
+        if BitcoinWallet.spend_fiat(upgrade_cost(Constants.CurrencyType.FIAT)):
 		upgrade_level = min(upgrade_level+1, upgrade_max_level)
 		return true
 	else:
 		# print("Not enough fiat balance: {0}".format([BitcoinWallet.get_fiat_balance()]))
 		return false
 
-func buy_max(currency_type: Currency.CurrencyType = Currency.CurrencyType.FIAT) -> void:
+func buy_max(currency_type: Constants.CurrencyType = Constants.CurrencyType.FIAT) -> void:
         if upgrade_level >= upgrade_max_level: return
 
-        if currency_type == Currency.CurrencyType.BITCOIN:
+        if currency_type == Constants.CurrencyType.BITCOIN:
                 BitcoinWallet.spend_bitcoin(_buy_max(currency_type))
         else:
                 BitcoinWallet.spend_fiat(_buy_max(currency_type))
 			# print("Not enough fiat balance: {0}".format([BitcoinWallet.get_fiat_balance()]))
 
-func _buy_max(currency_type: Currency.CurrencyType = Currency.CurrencyType.FIAT) -> float:
+func _buy_max(currency_type: Constants.CurrencyType = Constants.CurrencyType.FIAT) -> float:
         var balance: float = 0.0
 
-        balance = BitcoinWallet.get_bitcoin_balance() if currency_type == Currency.CurrencyType.BITCOIN else BitcoinWallet.get_fiat_balance()
+        balance = BitcoinWallet.get_bitcoin_balance() if currency_type == Constants.CurrencyType.BITCOIN else BitcoinWallet.get_fiat_balance()
 	
         var n: int = floor(_log((balance * (upgrade_cost_multiplier - 1.0)) / upgrade_cost(currency_type) + 1.0, upgrade_cost_multiplier))
 	if n >= upgrade_max_level: n = upgrade_max_level
@@ -129,8 +129,8 @@ func _buy_max(currency_type: Currency.CurrencyType = Currency.CurrencyType.FIAT)
 
 #region Cost
 
-func upgrade_cost(currency_type: Currency.CurrencyType = Currency.CurrencyType.FIAT) -> float:
-        return _upgrade_cost_btc() if currency_type == Currency.CurrencyType.BITCOIN else _upgrade_cost_fiat()
+func upgrade_cost(currency_type: Constants.CurrencyType = Constants.CurrencyType.FIAT) -> float:
+        return _upgrade_cost_btc() if currency_type == Constants.CurrencyType.BITCOIN else _upgrade_cost_fiat()
 
 func _upgrade_cost_fiat() -> float:
 	var inflation_adjustment = 1.0 + FED.get_total_inflation()
@@ -178,6 +178,6 @@ func check_next_tier_unlock() -> bool:
 	return false
 
 func _to_string() -> String:
-        return "ID: %s"%_id + "\nLevel: %s"%upgrade_level + "\nFiat Cost: %s"%upgrade_cost(Currency.CurrencyType.FIAT) + "\nBitcoin Cost: %s"%upgrade_cost(Currency.CurrencyType.BITCOIN)
+        return "ID: %s"%_id + "\nLevel: %s"%upgrade_level + "\nFiat Cost: %s"%upgrade_cost(Constants.CurrencyType.FIAT) + "\nBitcoin Cost: %s"%upgrade_cost(Constants.CurrencyType.BITCOIN)
 
 #endregion

--- a/Scripts/UI/InfoPanelInNode.gd
+++ b/Scripts/UI/InfoPanelInNode.gd
@@ -22,13 +22,13 @@ class_name SkillInfoPanelInNode extends Control
 @onready var price_background: PanelContainer = $PanelContainer/VBoxContainer/PriceBackground
 
 ## There's no need for this bool, but save the state just in case
-var use_btc_icon: bool = false
+var currency: Currency.CurrencyType = Currency.CurrencyType.FIAT
 
 func _ready() -> void:
 	visible = false
 
-func activate_panel(title: String, description: String, cost: int, use_bitcoin: bool, is_maxed_out: bool = false) -> void:
-	change_labels(title, description, cost, use_bitcoin, is_maxed_out)
+func activate_panel(title: String, description: String, cost: int, currency_type: Currency.CurrencyType, is_maxed_out: bool = false) -> void:
+        change_labels(title, description, cost, currency_type, is_maxed_out)
 	visible = true
 	animation_component.start_tween()
 
@@ -37,45 +37,45 @@ func deactivate_panel() -> void:
 	animation_component.reset()
 	visible = false
 
-func _set_cost_icon(use_bitcoin: bool) -> void:
-	_set_use_btc_icon(use_bitcoin)
-	if use_bitcoin:
-		btc_texture.visible = true
-		fiat_texture.visible = false
-	else:
-		fiat_texture.visible = true
-		btc_texture.visible = false
+func _set_cost_icon(currency_type: Currency.CurrencyType) -> void:
+        _set_currency(currency_type)
+        if currency_type == Currency.CurrencyType.BITCOIN:
+                btc_texture.visible = true
+                fiat_texture.visible = false
+        else:
+                fiat_texture.visible = true
+                btc_texture.visible = false
 
-func change_labels(title: String, description: String, cost: int, use_bitcoin: bool = false, is_maxed_out: bool = false) -> void:
-	_set_use_btc_icon(use_bitcoin)
-	skill_title.text = title
-	if description.is_empty():
-		skill_description.hide()
-	else:
-		skill_description.text = description
-	
-	_set_cost_icon(use_bitcoin)
-	update_cost_label(cost, use_bitcoin, is_maxed_out)
+func change_labels(title: String, description: String, cost: int, currency_type: Currency.CurrencyType = Currency.CurrencyType.FIAT, is_maxed_out: bool = false) -> void:
+        _set_currency(currency_type)
+        skill_title.text = title
+        if description.is_empty():
+                skill_description.hide()
+        else:
+                skill_description.text = description
 
-func update_cost_label(cost: int, use_bitcoin: bool = false, is_maxed_out: bool = false) -> void:
-	_set_use_btc_icon(use_bitcoin)
-	_change_price_background(use_bitcoin, cost, is_maxed_out)
-	skill_cost.text = "WELL DONE!" if is_maxed_out else Utils.format_currency(cost, true)
+        _set_cost_icon(currency_type)
+        update_cost_label(cost, currency_type, is_maxed_out)
 
-func _change_price_background(use_bitcoin: bool, cost: float, is_maxed_out: bool = false) -> void:
-	price_background.remove_theme_stylebox_override("panel")
-	if is_maxed_out:
-		price_background.add_theme_stylebox_override("panel", max_ugraded_style)
-		skill_cost.label_settings = maxed_out_font
-		return
-	skill_cost.label_settings = normal_font
-	if _get_currency_balance(use_bitcoin) < cost:
-		price_background.add_theme_stylebox_override("panel", cannot_afford_upgrade_style)
-	else:
-		price_background.add_theme_stylebox_override("panel", can_afford_upgrade_style)
+func update_cost_label(cost: int, currency_type: Currency.CurrencyType = Currency.CurrencyType.FIAT, is_maxed_out: bool = false) -> void:
+        _set_currency(currency_type)
+        _change_price_background(currency_type, cost, is_maxed_out)
+        skill_cost.text = "WELL DONE!" if is_maxed_out else Utils.format_currency(cost, true)
 
-func _set_use_btc_icon(value: bool) -> void:
-	use_btc_icon = value
+func _change_price_background(currency_type: Currency.CurrencyType, cost: float, is_maxed_out: bool = false) -> void:
+        price_background.remove_theme_stylebox_override("panel")
+        if is_maxed_out:
+                price_background.add_theme_stylebox_override("panel", max_ugraded_style)
+                skill_cost.label_settings = maxed_out_font
+                return
+        skill_cost.label_settings = normal_font
+        if _get_currency_balance(currency_type) < cost:
+                price_background.add_theme_stylebox_override("panel", cannot_afford_upgrade_style)
+        else:
+                price_background.add_theme_stylebox_override("panel", can_afford_upgrade_style)
 
-func _get_currency_balance(use_bitcoin) -> float:
-	return BitcoinWallet.get_bitcoin_balance() if use_bitcoin else BitcoinWallet.get_fiat_balance()
+func _set_currency(value: Currency.CurrencyType) -> void:
+        currency = value
+
+func _get_currency_balance(currency_type) -> float:
+        return BitcoinWallet.get_bitcoin_balance() if currency_type == Currency.CurrencyType.BITCOIN else BitcoinWallet.get_fiat_balance()

--- a/Scripts/UI/InfoPanelInNode.gd
+++ b/Scripts/UI/InfoPanelInNode.gd
@@ -22,12 +22,12 @@ class_name SkillInfoPanelInNode extends Control
 @onready var price_background: PanelContainer = $PanelContainer/VBoxContainer/PriceBackground
 
 ## There's no need for this bool, but save the state just in case
-var currency: Currency.CurrencyType = Currency.CurrencyType.FIAT
+var currency: Constants.CurrencyType = Constants.CurrencyType.FIAT
 
 func _ready() -> void:
 	visible = false
 
-func activate_panel(title: String, description: String, cost: int, currency_type: Currency.CurrencyType, is_maxed_out: bool = false) -> void:
+func activate_panel(title: String, description: String, cost: int, currency_type: Constants.CurrencyType, is_maxed_out: bool = false) -> void:
         change_labels(title, description, cost, currency_type, is_maxed_out)
 	visible = true
 	animation_component.start_tween()
@@ -37,16 +37,16 @@ func deactivate_panel() -> void:
 	animation_component.reset()
 	visible = false
 
-func _set_cost_icon(currency_type: Currency.CurrencyType) -> void:
+func _set_cost_icon(currency_type: Constants.CurrencyType) -> void:
         _set_currency(currency_type)
-        if currency_type == Currency.CurrencyType.BITCOIN:
+        if currency_type == Constants.CurrencyType.BITCOIN:
                 btc_texture.visible = true
                 fiat_texture.visible = false
         else:
                 fiat_texture.visible = true
                 btc_texture.visible = false
 
-func change_labels(title: String, description: String, cost: int, currency_type: Currency.CurrencyType = Currency.CurrencyType.FIAT, is_maxed_out: bool = false) -> void:
+func change_labels(title: String, description: String, cost: int, currency_type: Constants.CurrencyType = Constants.CurrencyType.FIAT, is_maxed_out: bool = false) -> void:
         _set_currency(currency_type)
         skill_title.text = title
         if description.is_empty():
@@ -57,12 +57,12 @@ func change_labels(title: String, description: String, cost: int, currency_type:
         _set_cost_icon(currency_type)
         update_cost_label(cost, currency_type, is_maxed_out)
 
-func update_cost_label(cost: int, currency_type: Currency.CurrencyType = Currency.CurrencyType.FIAT, is_maxed_out: bool = false) -> void:
+func update_cost_label(cost: int, currency_type: Constants.CurrencyType = Constants.CurrencyType.FIAT, is_maxed_out: bool = false) -> void:
         _set_currency(currency_type)
         _change_price_background(currency_type, cost, is_maxed_out)
         skill_cost.text = "WELL DONE!" if is_maxed_out else Utils.format_currency(cost, true)
 
-func _change_price_background(currency_type: Currency.CurrencyType, cost: float, is_maxed_out: bool = false) -> void:
+func _change_price_background(currency_type: Constants.CurrencyType, cost: float, is_maxed_out: bool = false) -> void:
         price_background.remove_theme_stylebox_override("panel")
         if is_maxed_out:
                 price_background.add_theme_stylebox_override("panel", max_ugraded_style)
@@ -74,8 +74,8 @@ func _change_price_background(currency_type: Currency.CurrencyType, cost: float,
         else:
                 price_background.add_theme_stylebox_override("panel", can_afford_upgrade_style)
 
-func _set_currency(value: Currency.CurrencyType) -> void:
+func _set_currency(value: Constants.CurrencyType) -> void:
         currency = value
 
 func _get_currency_balance(currency_type) -> float:
-        return BitcoinWallet.get_bitcoin_balance() if currency_type == Currency.CurrencyType.BITCOIN else BitcoinWallet.get_fiat_balance()
+        return BitcoinWallet.get_bitcoin_balance() if currency_type == Constants.CurrencyType.BITCOIN else BitcoinWallet.get_fiat_balance()

--- a/Scripts/UI/currency_ui.gd
+++ b/Scripts/UI/currency_ui.gd
@@ -1,6 +1,6 @@
 class_name CurrencyUI extends Control
 
-signal currency_changed(currency: Currency.CurrencyType)
+signal currency_changed(currency: Constants.CurrencyType)
 
 @export var main_event_bus: MainEventBus
 
@@ -42,6 +42,6 @@ func _on_money_changed(amount: float, is_bitcoin: bool = false) -> void:
 		btc_label.text = amount_text
 
 func _on_use_btc_button_toggled(toggled_on: bool) -> void:
-        var currency := Currency.CurrencyType.BITCOIN if toggled_on else Currency.CurrencyType.FIAT
+        var currency := Constants.CurrencyType.BITCOIN if toggled_on else Constants.CurrencyType.FIAT
         main_event_bus.currency_changed.emit(currency)
         currency_changed.emit(currency)

--- a/Scripts/UI/currency_ui.gd
+++ b/Scripts/UI/currency_ui.gd
@@ -1,6 +1,6 @@
 class_name CurrencyUI extends Control
 
-signal use_btc_toggled(toggled_on: bool)
+signal currency_changed(currency: Currency.CurrencyType)
 
 @export var main_event_bus: MainEventBus
 
@@ -42,4 +42,6 @@ func _on_money_changed(amount: float, is_bitcoin: bool = false) -> void:
 		btc_label.text = amount_text
 
 func _on_use_btc_button_toggled(toggled_on: bool) -> void:
-	main_event_bus.use_btc_toggled_ui.emit(toggled_on)
+        var currency := Currency.CurrencyType.BITCOIN if toggled_on else Currency.CurrencyType.FIAT
+        main_event_bus.currency_changed.emit(currency)
+        currency_changed.emit(currency)

--- a/Scripts/Utils/Constants.gd
+++ b/Scripts/Utils/Constants.gd
@@ -93,3 +93,8 @@ enum AbilityNames {
 	MAGNET,
 	REGEN_HEALTH_OVER_TIME,
 }
+
+enum CurrencyType {
+	FIAT,
+	BITCOIN,
+}

--- a/Scripts/Utils/Currency.gd
+++ b/Scripts/Utils/Currency.gd
@@ -1,7 +1,0 @@
-class_name Currency
-
-enum CurrencyType {
-    FIAT,
-    BITCOIN
-}
-

--- a/Scripts/Utils/Currency.gd
+++ b/Scripts/Utils/Currency.gd
@@ -1,0 +1,7 @@
+class_name Currency
+
+enum CurrencyType {
+    FIAT,
+    BITCOIN
+}
+

--- a/Scripts/Utils/MainEventBus.gd
+++ b/Scripts/Utils/MainEventBus.gd
@@ -3,7 +3,7 @@ class_name MainEventBus extends Resource
 
 signal level_completed(args: LevelCompletedArgs)
 signal bullet_pool_setted(args: BulletPoolSettedArgs)
-signal use_btc_toggled_ui(toggled_on: bool)
+signal currency_changed(currency: Currency.CurrencyType)
 
 func emit_bullet_pool_setted(_pools: Dictionary) -> void:
 	print_debug("Pools Setted")

--- a/Scripts/Utils/MainEventBus.gd
+++ b/Scripts/Utils/MainEventBus.gd
@@ -3,7 +3,7 @@ class_name MainEventBus extends Resource
 
 signal level_completed(args: LevelCompletedArgs)
 signal bullet_pool_setted(args: BulletPoolSettedArgs)
-signal currency_changed(currency: Currency.CurrencyType)
+signal currency_changed(currency: Constants.CurrencyType)
 
 func emit_bullet_pool_setted(_pools: Dictionary) -> void:
 	print_debug("Pools Setted")


### PR DESCRIPTION
## Summary
- add `Currency.gd` with `CurrencyType` enum
- emit `currency_changed` in `MainEventBus`
- update `CurrencyUI` to emit currency enum on toggle
- refactor `SkillNode`, `SkillNodeData`, `InfoPanelInNode`, and `UpgradeService` to work with `CurrencyType`
- store active currency in `UpgradeService`

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_685da6fff620832d8579e82e1ca1d407