### PR TITLE
Fix reward logic to track bitcoins in circulation accurately

### DIFF
--- a/Scripts/BitcoinNetwork/BitcoinWallet.gd
+++ b/Scripts/BitcoinNetwork/BitcoinWallet.gd
@@ -71,8 +71,8 @@ func spend_bitcoin(amount_to_spend: float) -> bool:
 	if amount_to_spend > bitcoin_balance:
 		return false
 	
-	bitcoin_balance -= amount_to_spend
-	BitcoinNetwork.set_bitcoins_spent(amount_to_spend)
+       bitcoin_balance -= amount_to_spend
+       BitcoinNetwork.add_coins_spent(amount_to_spend)
 	money_changed.emit(bitcoin_balance, true)
 	#emit_signal("money_changed", bitcoin_balance, true)
 	return true

--- a/Scripts/Miscelaneous/NetworkVisualizer.gd
+++ b/Scripts/Miscelaneous/NetworkVisualizer.gd
@@ -14,8 +14,8 @@ func _ready() -> void:
 func set_textes() -> void:
 	coins_lost.text = "Coins Lost: %.2f" % BitcoinNetwork.coins_lost
 	coins_on_player.text = "Coins in Wallet: %.2f" % BitcoinWallet.get_bitcoin_balance()
-	var left_to_mine: float = BitcoinNetwork.TOTAL_COINS - (BitcoinNetwork.coins_lost + BitcoinWallet.get_bitcoin_balance())
-	coins_left.text = "Coins Left to Mine: %.2f" % left_to_mine
+       var left_to_mine: float = BitcoinNetwork.TOTAL_COINS - BitcoinNetwork.get_total_bitcoins_in_circulation()
+       coins_left.text = "Coins Left to Mine: %.2f" % left_to_mine
 
 func set_block_visualizers() -> void:
 	var chain_copy: Array = BitcoinNetwork.chain.duplicate()


### PR DESCRIPTION
## Summary
- compute coins in circulation without changing the stored value
- restore bitcoins in circulation when loading data
- clamp block reward so total supply never exceeds the limit
- drop the obsolete coin limit check
- update visualizer to show coins left using BitcoinNetwork API
- add helpers to track lost and spent coins
- ensure halving schedule respects the coin cap

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685dbd6dbc0c832daf52796854ef116d