### PR TITLE
Fix level completion tracking

### DIFF
--- a/Scripts/BitcoinNetwork/BitcoinNetwork.gd
+++ b/Scripts/BitcoinNetwork/BitcoinNetwork.gd
@@ -89,10 +89,13 @@ func add_coins_spent(value: float) -> void:
        coins_spent += value
 
 func get_block_by_id(id: int) -> BitcoinBlock:
-	for b in chain:
-		if b.height == id:
-			return b
-	return null
+        for b in chain:
+                if b.height == id:
+                        return b
+        return null
+
+func is_level_mined(level_index: int) -> bool:
+        return get_block_by_id(level_index) != null
 
 func get_block_by_hash(_hash: String) -> BitcoinBlock:
 	for b in chain:

--- a/Scripts/Managers/GameManager.gd
+++ b/Scripts/Managers/GameManager.gd
@@ -49,12 +49,8 @@ func complete_level(code: String = "") -> void:
 func emit_level_completed(code: String = "") -> void:
 	main_event_bus.level_completed.emit(MainEventBus.LevelCompletedArgs.new(code))
 
-func player_in_completed_level() -> bool:
-	if levels_unlocked < previous_levels_unlocked_index:
-		return true
-	if _current_level < previous_levels_unlocked_index - 1: # Means the player is in an already completed level
-		return true
-	return false
+func player_in_completed_level(level_index: int = _current_level) -> bool:
+        return level_index < levels_unlocked - 1
 
 func init_tween() -> Tween:
 	return create_tween()

--- a/Scripts/Player/CurrencyInventory.gd
+++ b/Scripts/Player/CurrencyInventory.gd
@@ -5,10 +5,12 @@ func add_to_inventory(resource: Resource, amount: float) -> bool:
 		match resource.currency_type:
 			CurrencyPickupResource.CURRENCY_TYPE.FIAT:
 				return true
-			# TEST - Mine the block when the pickup is picked up
-			CurrencyPickupResource.CURRENCY_TYPE.BTC:
-				BitcoinNetwork.mine_block("Player")
-				return true
+                        # Mine a new block only if this level hasn't been mined before
+                        CurrencyPickupResource.CURRENCY_TYPE.BTC:
+                                var lvl: int = GameManager.get_current_level()
+                                if !BitcoinNetwork.is_level_mined(lvl):
+                                        BitcoinNetwork.mine_block("Player")
+                                return true
 			CurrencyPickupResource.CURRENCY_TYPE.NONE:
 				return false
 			_:

--- a/Scripts/QuadrantTerrain/BlockCore.gd
+++ b/Scripts/QuadrantTerrain/BlockCore.gd
@@ -134,11 +134,12 @@ func _spawn_fracture_body(fracture_info: Dictionary, texture_info: Dictionary) -
 	body_instance.setTexture(PolygonLib.setTextureOffset(texture_info, fracture_info.centroid))
 
 func _mine_block(miner: String = "Player") -> void:
-	var block: BitcoinBlock = null
-	if GameManager.player_in_completed_level():
-		block = BitcoinNetwork.get_block_by_id(GameManager.get_current_level())
+        var level_id: int = GameManager.get_current_level()
+        var block: BitcoinBlock = null
+        if BitcoinNetwork.is_level_mined(level_id):
+                block = BitcoinNetwork.get_block_by_id(level_id)
 
-	BitcoinNetwork.mine_block(miner, block)
+        BitcoinNetwork.mine_block(miner, block)
 
 func _on_slow_down_timer_timeout() -> void:
 	print_debug("Slow down timer timeout")

--- a/Scripts/UI/LevelFinishedUI.gd
+++ b/Scripts/UI/LevelFinishedUI.gd
@@ -53,20 +53,21 @@ func _on_item_picked(event : PickupEvent) -> void:
 	
 	if pickup is not CurrencyPickupResource: return
 	
-	var block: BitcoinBlock = BitcoinNetwork.get_block_by_id(GameManager.get_current_level())
-	match pickup.currency_type:
+        var level_id: int = GameManager.get_current_level()
+        var block: BitcoinBlock = BitcoinNetwork.get_block_by_id(level_id)
+        match pickup.currency_type:
 		CurrencyPickupResource.CURRENCY_TYPE.FIAT:
 			fiat_gained_so_far += event.pickup.resource_count
 		CurrencyPickupResource.CURRENCY_TYPE.BTC:
 			event.pickup.resource_count = BitcoinNetwork.get_block_subsidy()
 			btc_gained_this_time += event.pickup.resource_count
 			
-			if GameManager.player_in_completed_level():
-				btc_gained_this_time = 0
-				GameManager.complete_level(Constants.ERROR_500)
-			elif block.miner == "Player":
-				GameManager.complete_level(Constants.ERROR_200)
-			else:
-				GameManager.complete_level(Constants.ERROR_401)
+                        if GameManager.player_in_completed_level():
+                                btc_gained_this_time = 0
+                                GameManager.complete_level(Constants.ERROR_500)
+                        elif block == null or block.miner == "Player":
+                                GameManager.complete_level(Constants.ERROR_200)
+                        else:
+                                GameManager.complete_level(Constants.ERROR_401)
 		CurrencyPickupResource.CURRENCY_TYPE.NONE:
 			pass


### PR DESCRIPTION
## Summary
- provide `BitcoinNetwork.is_level_mined` helper
- prevent duplicate mining by checking mined levels in `CurrencyInventory`
- avoid null access in `LevelFinishedUI`
- update `BlockCore` mining helper
- simplify `GameManager.player_in_completed_level`

## Testing
- `godot4 --headless --quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cf3f4c7fc832d8d55b67dcbf4d9bc